### PR TITLE
registerPlugin must match configurePlugin

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -26,7 +26,7 @@ call_user_func(
         );
 
         \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-            $extensionKey,
+            'Romm.' . $extensionKey,
             'Example',
             '[FormZ] Forms example'
         );


### PR DESCRIPTION
see documentation at
https://docs.typo3.org/typo3cms/ExtbaseFluidBook/b-ExtbaseReference/Index.html

I do not understand why this did work in spite of this error.