### PR TITLE
add $pluginName as a variable

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -25,13 +25,15 @@ call_user_func(
             '[FormZ] Forms example - Assets for Foundation 5 Assets'
         );
 
+        $pluginName = 'Example';
         \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
             $extensionKey,
-            'Example',
+            $pluginName,
             '[FormZ] Forms example'
         );
 
-        $defaultPluginKey = 'formzexample_example';
+        $extensionCode = strtolower(\TYPO3\CMS\Core\Utility\GeneralUtility::underscoredToUpperCamelCase($extensionKey));
+        $defaultPluginKey = $extensionCode . '_' . strtolower($pluginName);
         $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist'][$defaultPluginKey] = 'pi_flexform';
         $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist'][$defaultPluginKey] = 'recursive,select_key,pages';
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($defaultPluginKey, "FILE:EXT:$extensionKey/Configuration/FlexForms/FlexForm.xml");

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -6,10 +6,12 @@ if (!defined('TYPO3_MODE')) {
 /** @noinspection PhpUndefinedVariableInspection */
 call_user_func(
     function ($extensionKey) {
+        $pluginName = 'Example';
+
         // Plugin registration
         \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
             'Romm.' . $extensionKey,
-            'Example',
+            $pluginName,
             array(
                 'MultiLayoutExample' => 'showForm, submitForm'
             ),


### PR DESCRIPTION
Please make this example better to understand and use by others.

    $pluginName = 'Example';

Do not hardcode the $defaultPluginKey. This leads to confusion.