### PR TITLE
add empty contructor class 1297759968

### DIFF
--- a/Classes/Form/ExampleForm.php
+++ b/Classes/Form/ExampleForm.php
@@ -56,6 +56,10 @@ class ExampleForm implements FormInterface
      */
     protected $iceCreamFlavors;
 
+    public function __construct()
+    {
+    }
+
     /**
      * @return string
      */


### PR DESCRIPTION
An exception #1297759968 is thrown after a submit in TYPO3 6.2.31.

see 
https://wiki.typo3.org/Exception/CMS/1297759968